### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from setuptools import setup
 
 setup(
-	name='sneazr',
+    name='sneazr',
     version = '0.1b1',
-    scripts = ['sneaze.py'],
+    py_modules=['sneaze'],
     author = 'Jesse Miller',
     author_email = 'millerjesse@gmail.com',
     description = 'Have nosetests notify to growl',
     keywords = 'nose tests growl',
-    url = 'http://github.com/jessemiller/Sneazr',	
+    url = 'http://github.com/jessemiller/Sneazr',
     setup_requires=['setuptools-git'],
     tests_require=['nose'],
     install_requires=[
-        'nose'
-    ],      
+        'nose',
+        'py-Growl',
+    ],
     entry_points = {
-    	'nose.plugins.0.10': ['sneazr = sneaze:Sneazr']
+        'nose.plugins.0.10': ['sneazr = sneaze:Sneazr']
     }
 )


### PR DESCRIPTION
Hi,

Once installed, nose failed to find the plugin, so I fixed the setup.py to install sneazr as a module (in site-packages) and not as a script (in bin).

I also added a dependency on the py-Growl package which provides Growl bindings.
